### PR TITLE
style: change print width to 120

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,11 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true
+
+[*.markdown]
+trim_trailing_whitespace = false
 
 # Matches multiple files with brace expansion notation
 # Set default charset
@@ -28,4 +33,3 @@ indent_style = tab
 [{package.json,.travis.yml}]
 indent_style = space
 indent_size = 2
-

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,7 +6,7 @@
   "singleQuote": false,
   "jsxSingleQuote": true,
   "endOfLine": "lf",
-  "printWidth": 80,
+  "printWidth": 120,
   "bracketSpacing": true,
   "arrowParens": "always",
   "useTabs": false


### PR DESCRIPTION
Most modern developers have at least 1080p screens, and 80 characters is obviously not enough for us. In the case of ensuring no horizontal scrolling, 120 is a more appropriate choice